### PR TITLE
游戏本体目录名不为“Genshin Impact Game"时无法识别游戏存在

### DIFF
--- a/Genshin-LauncherDIY/GenShin-LauncherDIY/Class/IniSet.cs
+++ b/Genshin-LauncherDIY/GenShin-LauncherDIY/Class/IniSet.cs
@@ -298,7 +298,7 @@ namespace GenShin_LauncherDIY.Config
         /// <returns></returns>  
         public static string ReadIni(string section, string key)
         {
-            string IniFilePath = Config.IniGS.gamePath + @"\\Genshin Impact Game\\config.ini";
+            string IniFilePath = Config.IniGS.gamePath + @"\\config.ini";
             StringBuilder temp = new StringBuilder(255);
             int i = GetPrivateProfileString(section, key, "", temp, 255, IniFilePath);
             return temp.ToString();
@@ -314,7 +314,7 @@ namespace GenShin_LauncherDIY.Config
         /// <returns></returns>  
         public static void WriteIni(string section, string key, string value)
         {
-            string IniFilePath = Config.IniGS.gamePath + @"\\Genshin Impact Game\\config.ini";
+            string IniFilePath = Config.IniGS.gamePath + @"\\config.ini";
             WritePrivateProfileString(section, key, value, IniFilePath);
         }
         /// <summary>  
@@ -325,7 +325,7 @@ namespace GenShin_LauncherDIY.Config
         /// <returns></returns>  
         public static long DeleteSection(string section)
         {
-            string IniFilePath = Config.IniGS.gamePath + @"\\Genshin Impact Game\\config.ini";
+            string IniFilePath = Config.IniGS.gamePath + @"\\config.ini";
             return WritePrivateProfileString(section, null, null, IniFilePath);
         }
 
@@ -338,7 +338,7 @@ namespace GenShin_LauncherDIY.Config
         /// <returns></returns>  
         public static long DeleteKey(string section, string key)
         {
-            string IniFilePath = Config.IniGS.gamePath + @"\\Genshin Impact Game\\config.ini";
+            string IniFilePath = Config.IniGS.gamePath + @"\\config.ini";
             return WritePrivateProfileString(section, key, null, IniFilePath);
         }
     }

--- a/Genshin-LauncherDIY/GenShin-LauncherDIY/Class/Utils.cs
+++ b/Genshin-LauncherDIY/GenShin-LauncherDIY/Class/Utils.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -113,6 +114,19 @@ namespace GenShin_LauncherDIY.Utils
                 pc.StandardInput.AutoFlush = true;
                 pc.Close();
             }
+        }
+
+        [DllImport("kernel32")]
+        private static extern int GetPrivateProfileString(string section, string key, string def, StringBuilder retVal, int size, string filePath);
+
+        public static string readIniFile(string IniFilePath,string section, string key)
+        {
+            StringBuilder temp = new StringBuilder(255);
+            int i = GetPrivateProfileString(section, key, "", temp, 255, IniFilePath);
+            if (i == 0)
+                return null;
+            else
+                return temp.ToString();
         }
     }
     class checkTool

--- a/Genshin-LauncherDIY/GenShin-LauncherDIY/MainWindow.xaml.cs
+++ b/Genshin-LauncherDIY/GenShin-LauncherDIY/MainWindow.xaml.cs
@@ -87,7 +87,7 @@ namespace GenShin_LauncherDIY
                     var stream = Application.GetResourceStream(uri).Stream;
                     Utils.UtilsTools.StreamToFile(stream, @"unlockfps.exe");
                 }
-                if (File.Exists(Config.Settings.GamePath + "//Genshin Impact Game//YuanShen.exe") == true)//启动国服
+                if (File.Exists(Config.Settings.GamePath + "//YuanShen.exe") == true)//启动国服
                 {
                     Process.Start(@"unlockfps.exe");
                     Thread game = new Thread(() =>
@@ -95,13 +95,13 @@ namespace GenShin_LauncherDIY
                         //次线程，防止UI假死
                         Dispatcher.Invoke(new Action(() =>
                         {
-                            UtilsTools.Rungenshin(Config.Settings.GamePath.Substring(0, 1) + ":", "cd " + Config.Settings.GamePath + "//Genshin Impact Game", "YuanShen.exe " + "-screen-fullscreen " + Config.Settings.FullS + " -screen-height " + Config.Settings.Height + " -screen-width " + Config.Settings.Width + Config.Settings.GamePopup);
+                            UtilsTools.Rungenshin(Config.Settings.GamePath.Substring(0, 1) + ":", "cd " + Config.Settings.GamePath + "", "YuanShen.exe " + "-screen-fullscreen " + Config.Settings.FullS + " -screen-height " + Config.Settings.Height + " -screen-width " + Config.Settings.Width + Config.Settings.GamePopup);
                         }));
                     });
                     game.Start();
                     WindowState = WindowState.Minimized;
                 }
-                else if (File.Exists(Config.Settings.GamePath + "//Genshin Impact Game//GenshinImpact.exe") == true)//启动国际服
+                else if (File.Exists(Config.Settings.GamePath + "//GenshinImpact.exe") == true)//启动国际服
                 {
                     Process.Start(@"unlockfps.exe");
                     Thread game = new Thread(() =>
@@ -109,7 +109,7 @@ namespace GenShin_LauncherDIY
                         //次线程，防止UI假死
                         Dispatcher.Invoke(new Action(() =>
                         {
-                            UtilsTools.Rungenshin(Config.Settings.GamePath.Substring(0, 1) + ":", "cd " + Config.Settings.GamePath + "//Genshin Impact Game", "GenshinImpact.exe " + "-screen-fullscreen " + Config.Settings.FullS + " -screen-height " + Config.Settings.Height + " -screen-width " + Config.Settings.Width);
+                            UtilsTools.Rungenshin(Config.Settings.GamePath.Substring(0, 1) + ":", "cd " + Config.Settings.GamePath , "GenshinImpact.exe " + "-screen-fullscreen " + Config.Settings.FullS + " -screen-height " + Config.Settings.Height + " -screen-width " + Config.Settings.Width);
                         }));
                     });
                     game.Start();
@@ -122,27 +122,27 @@ namespace GenShin_LauncherDIY
             }
             else if (Config.IniGS.isUnFPS == false)
             {
-                if (File.Exists(Config.Settings.GamePath + "//Genshin Impact Game//YuanShen.exe") == true)//启动国服
+                if (File.Exists(Config.Settings.GamePath + "//YuanShen.exe") == true)//启动国服
                 {
                     Thread game = new Thread(() =>
                     {
                         //次线程，防止UI假死
                         Dispatcher.Invoke(new Action(() =>
                         {
-                            UtilsTools.Rungenshin(Config.Settings.GamePath.Substring(0, 1) + ":", "cd " + Config.Settings.GamePath + "//Genshin Impact Game", "YuanShen.exe " + "-screen-fullscreen " + Config.Settings.FullS + " -screen-height " + Config.Settings.Height + " -screen-width " + Config.Settings.Width + Config.Settings.GamePopup);
+                            UtilsTools.Rungenshin(Config.Settings.GamePath.Substring(0, 1) + ":", "cd " + Config.Settings.GamePath, "YuanShen.exe " + "-screen-fullscreen " + Config.Settings.FullS + " -screen-height " + Config.Settings.Height + " -screen-width " + Config.Settings.Width + Config.Settings.GamePopup);
                         }));
                     });
                     game.Start();
                     WindowState = WindowState.Minimized;
                 }
-                else if (File.Exists(Config.Settings.GamePath + "//Genshin Impact Game//GenshinImpact.exe") == true)//启动国际服
+                else if (File.Exists(Config.Settings.GamePath + "//GenshinImpact.exe") == true)//启动国际服
                 {
                     Thread game = new Thread(() =>
                     {
                         //次线程，防止UI假死
                         Dispatcher.Invoke(new Action(() =>
                         {
-                            UtilsTools.Rungenshin(Config.Settings.GamePath.Substring(0, 1) + ":", "cd " + Config.Settings.GamePath + "//Genshin Impact Game", "GenshinImpact.exe " + "-screen-fullscreen " + Config.Settings.FullS + " -screen-height " + Config.Settings.Height + " -screen-width " + Config.Settings.Width);
+                            UtilsTools.Rungenshin(Config.Settings.GamePath.Substring(0, 1) + ":", "cd " + Config.Settings.GamePath, "GenshinImpact.exe " + "-screen-fullscreen " + Config.Settings.FullS + " -screen-height " + Config.Settings.Height + " -screen-width " + Config.Settings.Width);
                         }));
                     });
                     game.Start();
@@ -155,27 +155,27 @@ namespace GenShin_LauncherDIY
             }
             else
             {
-                if (File.Exists(Config.Settings.GamePath + "//Genshin Impact Game//YuanShen.exe") == true)//启动国服
+                if (File.Exists(Config.Settings.GamePath + "//YuanShen.exe") == true)//启动国服
                 {
                     Thread game = new Thread(() =>
                     {
                     //次线程，防止UI假死
                     Dispatcher.Invoke(new Action(() =>
                         {
-                            UtilsTools.Rungenshin(Config.Settings.GamePath.Substring(0, 1) + ":", "cd " + Config.Settings.GamePath + "//Genshin Impact Game", "YuanShen.exe " + "-screen-fullscreen " + Config.Settings.FullS + " -screen-height " + Config.Settings.Height + " -screen-width " + Config.Settings.Width + Config.Settings.GamePopup);
+                            UtilsTools.Rungenshin(Config.Settings.GamePath.Substring(0, 1) + ":", "cd " + Config.Settings.GamePath, "YuanShen.exe " + "-screen-fullscreen " + Config.Settings.FullS + " -screen-height " + Config.Settings.Height + " -screen-width " + Config.Settings.Width + Config.Settings.GamePopup);
                         }));
                     });
                     game.Start();
                     WindowState = WindowState.Minimized;
                 }
-                else if (File.Exists(Config.Settings.GamePath + "//Genshin Impact Game//GenshinImpact.exe") == true)//启动国际服
+                else if (File.Exists(Config.Settings.GamePath + "//GenshinImpact.exe") == true)//启动国际服
                 {
                     Thread game = new Thread(() =>
                     {
                     //次线程，防止UI假死
                     Dispatcher.Invoke(new Action(() =>
                         {
-                            UtilsTools.Rungenshin(Config.Settings.GamePath.Substring(0, 1) + ":", "cd " + Config.Settings.GamePath + "//Genshin Impact Game", "GenshinImpact.exe " + "-screen-fullscreen " + Config.Settings.FullS + " -screen-height " + Config.Settings.Height + " -screen-width " + Config.Settings.Width);
+                            UtilsTools.Rungenshin(Config.Settings.GamePath.Substring(0, 1) + ":", "cd " + Config.Settings.GamePath, "GenshinImpact.exe " + "-screen-fullscreen " + Config.Settings.FullS + " -screen-height " + Config.Settings.Height + " -screen-width " + Config.Settings.Width);
                         }));
                     });
                     game.Start();
@@ -200,9 +200,9 @@ namespace GenShin_LauncherDIY
 
         private void ScreenSrc_Click(object sender, RoutedEventArgs e)
         {
-            if (Directory.Exists(Config.Settings.GamePath + "//Genshin Impact Game//ScreenShot") == true)
+            if (Directory.Exists(Config.Settings.GamePath + "//ScreenShot") == true)
             {
-                Process.Start(Config.Settings.GamePath + "//Genshin Impact Game//ScreenShot");
+                Process.Start(Config.Settings.GamePath + "//ScreenShot");
 
             }
             else

--- a/Genshin-LauncherDIY/GenShin-LauncherDIY/setWindow.xaml
+++ b/Genshin-LauncherDIY/GenShin-LauncherDIY/setWindow.xaml
@@ -24,7 +24,7 @@
             </Grid>
         </GroupBox>
         <Button x:Name="setSave" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Content="保存" HorizontalAlignment="Left" Margin="560,237,0,0" VerticalAlignment="Top" Height="28" Width="64" Click="setSave_Click" FontFamily="Microsoft YaHei UI" FontSize="12" />
-        <TextBox mah:TextBoxHelper.Watermark="官方启动器所在目录，如游戏本体路径与启动器分离则填游戏上一级目录" x:Name="GamePath" x:FieldModifier="public" Height="23" Margin="10,206,201,0" TextWrapping="Wrap" VerticalAlignment="Top" FontFamily="Microsoft YaHei UI"/>
+        <TextBox mah:TextBoxHelper.Watermark="官方启动器文件位置 或 游戏本体文件位置" x:Name="GamePath" x:FieldModifier="public" Height="23" Margin="10,206,201,0" TextWrapping="Wrap" VerticalAlignment="Top" FontFamily="Microsoft YaHei UI"/>
         <RadioButton x:Name="BIliS" Content="B服启动" HorizontalAlignment="Left" Margin="89,242,0,0" VerticalAlignment="Top" FontFamily="Microsoft YaHei UI"/>
         <RadioButton x:Name="MiS" Content="官服启动" HorizontalAlignment="Left" Margin="10,242,0,0" VerticalAlignment="Top" FontFamily="Microsoft YaHei UI"/>
         <Label x:Name="SDKlive" Content="SDK:未知" HorizontalAlignment="Left" Margin="314,239,0,0" VerticalAlignment="Top" Width="65"/>

--- a/Genshin-LauncherDIY/GenShin-LauncherDIY/setWindow.xaml.cs
+++ b/Genshin-LauncherDIY/GenShin-LauncherDIY/setWindow.xaml.cs
@@ -99,6 +99,28 @@ namespace GenShin_LauncherDIY
                 e.Cancel = true;
             }
         }
+
+        private bool isGamePath(String path)
+        {
+            if (File.Exists(path + "\\mhyprot2.sys"))
+                return true;
+            else
+                return false;
+        }
+        
+        private string getRealPathFromOfficalLauncher(string officalLauncherPath)
+        {
+            return Utils.UtilsTools.readIniFile(officalLauncherPath + "\\config.ini", "launcher", "game_install_path");
+        }
+
+        private string getRealGamePath(string filePath)
+        {
+            if (isGamePath(filePath))
+                return filePath;
+            else
+                return getRealPathFromOfficalLauncher(filePath);
+        }
+
         private void setSave_Click(object sender, RoutedEventArgs e)
         {
             //游戏路径保存
@@ -109,13 +131,19 @@ namespace GenShin_LauncherDIY
             }
             else if (Directory.Exists(GamePath.Text) == false)
             {
-                this.ShowMessageAsync("错误", "游戏路径不存在,请输入正确的游戏路径！", MessageDialogStyle.Affirmative, new MetroDialogSettings() { AffirmativeButtonText = "确定" });
+                this.ShowMessageAsync("错误", "游戏路径不存在，请输入正确的游戏文件或启动器文件目录！\n如D:\\Games\\Genshin Impact Game", MessageDialogStyle.Affirmative, new MetroDialogSettings() { AffirmativeButtonText = "确定" });
                 return;
             }
             else
             {
-                Config.IniGS.gamePath = GamePath.Text;
-                Config.Settings.GamePath = GamePath.Text;
+                string gamePath = getRealGamePath(GamePath.Text);
+                if (gamePath == null)
+                {
+                    this.ShowMessageAsync("错误", "无法从所填路径获得游戏本体所在目录，请输入正确的游戏文件或启动器文件目录！\n如D:\\Games\\Genshin Impact Game", MessageDialogStyle.Affirmative, new MetroDialogSettings() { AffirmativeButtonText = "确定" });
+                    return;
+                }
+                Config.IniGS.gamePath = gamePath;
+                Config.Settings.GamePath = gamePath;
             }
             //游戏分辨率保存
             if (!Utils.checkTool.IsNumber(GWidth.Text) || !Utils.checkTool.IsNumber(GHeight.Text))
@@ -215,12 +243,12 @@ namespace GenShin_LauncherDIY
             }
             else
             {
-                if (File.Exists(GamePath.Text + "\\Genshin Impact Game\\YuanShen_Data\\Plugins\\PCGameSDK.dll") == true)
+                if (File.Exists(GamePath.Text + "\\YuanShen_Data\\Plugins\\PCGameSDK.dll") == true)
                 {
                     SDKlive.Content = "SDK:存在";
                     Fixbtn.IsEnabled = false;
                 }
-                else if (File.Exists(GamePath.Text + "\\Genshin Impact Game\\GenshinImpact_Data\\Plugins\\PCGameSDK.dll") == true)
+                else if (File.Exists(GamePath.Text + "\\GenshinImpact_Data\\Plugins\\PCGameSDK.dll") == true)
                 {
                     SDKlive.Content = "SDK:无需";
                     Fixbtn.IsEnabled = false;
@@ -236,12 +264,12 @@ namespace GenShin_LauncherDIY
         {
             if ((await this.ShowMessageAsync("提醒", "修复SDK仅用于官转哔服，国际服无需修复", MessageDialogStyle.AffirmativeAndNegative, new MetroDialogSettings() { AffirmativeButtonText = "取消", NegativeButtonText = "确定修复" })) != MessageDialogResult.Affirmative)
             {
-                if (Directory.Exists(Config.Settings.GamePath + "//Genshin Impact Game//YuanShen_Data") == true)
+                if (Directory.Exists(Config.Settings.GamePath + "//YuanShen_Data") == true)
                 {
                     var sdkUri = "pack://application:,,,/Res/mihoyosdk.dll";
                     var uri = new Uri(sdkUri, UriKind.RelativeOrAbsolute);
                     var stream = Application.GetResourceStream(uri).Stream;
-                    Utils.UtilsTools.StreamToFile(stream, GamePath.Text + "\\Genshin Impact Game\\YuanShen_Data\\Plugins\\PCGameSDK.dll");
+                    Utils.UtilsTools.StreamToFile(stream, GamePath.Text + "\\YuanShen_Data\\Plugins\\PCGameSDK.dll");
                     IsSDK();
                 }
                 else
@@ -374,10 +402,10 @@ namespace GenShin_LauncherDIY
             }));
             for (int a = 0; a < Settings.cnfiles.Length; a++)
             {
-                String newFileName = System.IO.Path.GetFileNameWithoutExtension(Config.Settings.GameMovePath + "//Genshin Impact Game//" + Settings.cnfiles[a]) + System.IO.Path.GetExtension(Config.Settings.GameMovePath + "//Genshin Impact Game//" + Settings.cnfiles[a]);
-                if (File.Exists(Config.Settings.GameMovePath + "//Genshin Impact Game//" + Settings.cnfiles[a]) == true)
+                String newFileName = System.IO.Path.GetFileNameWithoutExtension(Config.Settings.GameMovePath + "//" + Settings.cnfiles[a]) + System.IO.Path.GetExtension(Config.Settings.GameMovePath + "//" + Settings.cnfiles[a]);
+                if (File.Exists(Config.Settings.GameMovePath + "//" + Settings.cnfiles[a]) == true)
                 {
-                    redir.FileSystem.RenameFile(Config.Settings.GameMovePath + "//Genshin Impact Game//" + Settings.cnfiles[a], newFileName + ".bak");
+                    redir.FileSystem.RenameFile(Config.Settings.GameMovePath + "//" + Settings.cnfiles[a], newFileName + ".bak");
                     this.Dispatcher.Invoke(new Action(delegate ()
                     {
                         LogBox.Content = newFileName + "备份成功";
@@ -395,10 +423,10 @@ namespace GenShin_LauncherDIY
             {
                 TimeStatus.Content = "当前状态：开始替换资源";
             }));
-            redir.FileSystem.RenameDirectory(Config.Settings.GameMovePath + "//Genshin Impact Game//YuanShen_Data", "GenshinImpact_Data");
+            redir.FileSystem.RenameDirectory(Config.Settings.GameMovePath + "//YuanShen_Data", "GenshinImpact_Data");
             for (int i = 0; i < Settings.globalfiles.Length; i++)
             {
-                File.Copy(@"GlobalFile//" + Settings.globalfiles[i], Config.Settings.GameMovePath + "//Genshin Impact Game//" + Settings.globalfiles[i], true);
+                File.Copy(@"GlobalFile//" + Settings.globalfiles[i], Config.Settings.GameMovePath + "//" + Settings.globalfiles[i], true);
                 this.Dispatcher.Invoke(new Action(delegate ()
                 {
                     LogBox.Content = Settings.globalfiles[i] + "替换成功";
@@ -408,8 +436,8 @@ namespace GenShin_LauncherDIY
             {
                 TimeStatus.Content = "当前状态：无状态";
             }));
-            if (File.Exists(Config.Settings.GameMovePath + "\\Genshin Impact Game\\GenshinImpact_Data\\Plugins\\PCGameSDK.dll") == true)
-                File.Delete(Config.Settings.GameMovePath + "\\Genshin Impact Game\\GenshinImpact_Data\\Plugins\\PCGameSDK.dll");
+            if (File.Exists(Config.Settings.GameMovePath + "\\GenshinImpact_Data\\Plugins\\PCGameSDK.dll") == true)
+                File.Delete(Config.Settings.GameMovePath + "\\GenshinImpact_Data\\Plugins\\PCGameSDK.dll");
             Config.IniGS.BiOrMi = 3;
             BOM.Sub_channel = 0;
             BOM.Channel = 1;
@@ -424,7 +452,7 @@ namespace GenShin_LauncherDIY
         }
         private void IsGlobal()
         {
-            if (File.Exists(Config.Settings.GamePath + "//Genshin Impact Game//YuanShen.exe") == true)
+            if (File.Exists(Config.Settings.GamePath + "//YuanShen.exe") == true)
             {
                 ToGlobal.Content = "转换";
                 GlobalS.IsEnabled = false;
@@ -433,7 +461,7 @@ namespace GenShin_LauncherDIY
                 MiS.IsChecked = true;
 
             }
-            else if (File.Exists(Config.Settings.GamePath + "//Genshin Impact Game//GenshinImpact.exe") == true)
+            else if (File.Exists(Config.Settings.GamePath + "//GenshinImpact.exe") == true)
             {
                 ToGlobal.Content = "复原";
                 GlobalS.IsChecked = true;
@@ -451,9 +479,9 @@ namespace GenShin_LauncherDIY
             }));
             for (int i = 0; i < Settings.globalfiles.Length; i++)
             {
-                if (File.Exists(Config.Settings.GameMovePath + "//Genshin Impact Game//" + Settings.globalfiles[i]) == true)
+                if (File.Exists(Config.Settings.GameMovePath + "//" + Settings.globalfiles[i]) == true)
                 {
-                    File.Delete(Config.Settings.GameMovePath + "//Genshin Impact Game//" + Settings.globalfiles[i]);
+                    File.Delete(Config.Settings.GameMovePath + "//" + Settings.globalfiles[i]);
                     this.Dispatcher.Invoke(new Action(delegate ()
                     {
                         LogBox.Content = Settings.globalfiles[i] + "清理完毕";
@@ -471,14 +499,14 @@ namespace GenShin_LauncherDIY
             {
                 TimeStatus.Content = "当前状态：正在还原文件";
             }));
-            redir.FileSystem.RenameDirectory(Config.Settings.GameMovePath + "//Genshin Impact Game//GenshinImpact_Data", "YuanShen_Data");
+            redir.FileSystem.RenameDirectory(Config.Settings.GameMovePath + "//GenshinImpact_Data", "YuanShen_Data");
             int whole = 0, success = 0;
             for (int a = 0; a < Settings.cnfiles.Length; a++)
             {
-                String newFileName = System.IO.Path.GetFileNameWithoutExtension(Config.Settings.GameMovePath + "//Genshin Impact Game//" + Settings.cnfiles[a]) + System.IO.Path.GetExtension(Config.Settings.GameMovePath + "//Genshin Impact Game//" + Settings.cnfiles[a]); ;
-                if (File.Exists(Config.Settings.GameMovePath + "//Genshin Impact Game//" + Settings.cnfiles[a] + ".bak") == true)
+                String newFileName = System.IO.Path.GetFileNameWithoutExtension(Config.Settings.GameMovePath + "//" + Settings.cnfiles[a]) + System.IO.Path.GetExtension(Config.Settings.GameMovePath + "//" + Settings.cnfiles[a]); ;
+                if (File.Exists(Config.Settings.GameMovePath + "//" + Settings.cnfiles[a] + ".bak") == true)
                 {
-                    redir.FileSystem.RenameFile(Config.Settings.GameMovePath + "//Genshin Impact Game//" + Settings.cnfiles[a] + ".bak", newFileName);
+                    redir.FileSystem.RenameFile(Config.Settings.GameMovePath + "//" + Settings.cnfiles[a] + ".bak", newFileName);
                     this.Dispatcher.Invoke(new Action(delegate ()
                     {
                         LogBox.Content = Settings.cnfiles[a] + "还原成功";
@@ -498,7 +526,7 @@ namespace GenShin_LauncherDIY
             var sdkUri = "pack://application:,,,/Res/mihoyosdk.dll";
             var uri = new Uri(sdkUri, UriKind.RelativeOrAbsolute);
             var stream = Application.GetResourceStream(uri).Stream;
-            Utils.UtilsTools.StreamToFile(stream, Config.Settings.GameMovePath + "\\Genshin Impact Game\\YuanShen_Data\\Plugins\\PCGameSDK.dll");
+            Utils.UtilsTools.StreamToFile(stream, Config.Settings.GameMovePath + "\\YuanShen_Data\\Plugins\\PCGameSDK.dll");
             this.Dispatcher.Invoke(new Action(delegate ()
             {
                 IsSDK();


### PR DESCRIPTION
这个pr是解决issue #6 的。
主要修改了setWindow.xaml.cs和其他与游戏文件路径相关的代码。
在setWindow.xaml.cs中，可读取官方启动器中的config.ini来获得真正的游戏目录，或直接填入游戏本体exe文件所在的目录，例如我使用的的”D:\Games\Genshin Impact“。 

不过并没有考虑向下兼容性，意味着需要重新填写游戏路径