### PR TITLE
新功能：寻空每日一图

### DIFF
--- a/Genshin-LauncherDIY/GenShin_Launcher_Plus/Core/IniControl.cs
+++ b/Genshin-LauncherDIY/GenShin_Launcher_Plus/Core/IniControl.cs
@@ -402,7 +402,7 @@ namespace GenShin_Launcher_Plus.Core
             {
                 IniParser parser = new IniParser(Path.Combine(GamePath, "Config.ini"));
                 _Channel = Convert.ToUInt16(parser.GetSetting("General", "channel", 1));
-                return _Channel; 
+                return _Channel;
             }
             set
             {
@@ -445,6 +445,24 @@ namespace GenShin_Launcher_Plus.Core
                 IniParser parser = new IniParser(Path.Combine(GamePath, "Config.ini"));
                 _Cps = value;
                 parser.AddSetting("General", "cps", _Cps);
+                parser.SaveSettings();
+            }
+        }
+
+        private static bool _UserXunkongWallpaper;
+        public static bool UserXunkongWallpaper
+        {
+            get
+            {
+                IniParser parser = new IniParser();
+                _UserXunkongWallpaper = Convert.ToBoolean(parser.GetSetting("setup", "UserXunkongWallpaper", 2));
+                return _UserXunkongWallpaper;
+            }
+            set
+            {
+                IniParser parser = new IniParser();
+                _UserXunkongWallpaper = value;
+                parser.AddSetting("setup", "UserXunkongWallpaper", Convert.ToString(_UserXunkongWallpaper));
                 parser.SaveSettings();
             }
         }

--- a/Genshin-LauncherDIY/GenShin_Launcher_Plus/Models/SettingsIniModel.cs
+++ b/Genshin-LauncherDIY/GenShin_Launcher_Plus/Models/SettingsIniModel.cs
@@ -20,5 +20,6 @@ namespace GenShin_Launcher_Plus.Models
         public ushort isMihoyo { get; set; }
         public string Width { get; set; }
         public string Height { get; set; }
+        public bool UseXunkongWallpaper { get; set; }
     }
 }

--- a/Genshin-LauncherDIY/GenShin_Launcher_Plus/ViewModels/SettingsPageViewModel.cs
+++ b/Genshin-LauncherDIY/GenShin_Launcher_Plus/ViewModels/SettingsPageViewModel.cs
@@ -368,6 +368,7 @@ namespace GenShin_Launcher_Plus.ViewModels
             IniControl.isMainGridHide = IniModel.isMainGridHide;
             IniControl.isWebBg = IniModel.isWebBg;
             IniControl.FullSize = IniModel.FullSize;
+            IniControl.UserXunkongWallpaper = IniModel.UseXunkongWallpaper;
             if (File.Exists(Path.Combine(IniControl.GamePath, "config.ini")) == true)
             {
                 switch (IniModel.isMihoyo)
@@ -447,6 +448,7 @@ namespace GenShin_Launcher_Plus.ViewModels
             IniModel.FullSize = IniControl.FullSize;
             Width = IniModel.Width;
             Height = IniModel.Height;
+            IniModel.UseXunkongWallpaper = IniControl.UserXunkongWallpaper;
             ReadGameConfig();
         }
 

--- a/Genshin-LauncherDIY/GenShin_Launcher_Plus/Views/SettingsPage.xaml
+++ b/Genshin-LauncherDIY/GenShin_Launcher_Plus/Views/SettingsPage.xaml
@@ -29,6 +29,7 @@
             </Grid>
         </GroupBox>
         <CheckBox Content="不使用网络背景" HorizontalAlignment="Left" Margin="13,531,0,0" VerticalAlignment="Top" FontFamily="Microsoft YaHei UI" IsChecked="{Binding IniModel.isWebBg}"/>
+        <CheckBox Content="使用寻空每日一图" HorizontalAlignment="Left" Margin="136,531,0,0" VerticalAlignment="Top" FontFamily="Microsoft YaHei UI" IsChecked="{Binding IniModel.UseXunkongWallpaper}"/>
         <GroupBox HorizontalAlignment="Left" Height="216" VerticalAlignment="Top" Width="173" Header="附加与窗口分辨率" Margin="13,48,0,0">
             <Grid>
                 <TextBox mah:TextBoxHelper.Watermark="高度" x:Name="DisHeight" HorizontalAlignment="Left" Margin="93,14,0,0" TextWrapping="Wrap" Text="{Binding Height}" VerticalAlignment="Top" Width="54" FontFamily="Microsoft YaHei UI" FontWeight="Normal" TextAlignment="Center"/>


### PR DESCRIPTION
添加了每日自动切换壁纸的新功能，功能开启后，会忽略「不使用网络背景」设置项。
![image](https://user-images.githubusercontent.com/61003590/156999307-af17422d-3519-495d-8a66-012359776a12.png)

应用启动时，尝试加载之前已保存的图片，没有则使用嵌入程序集内的图片；
然后从网络获取今日推荐图片，替换应用内背景图，并将图片保存至本地供下载启动时使用。

文件夹内变更内容：
新增设置项  UseXunkongWallpaper (bool)
新增文件  Config/XunkongWallpaper.jpg

破坏性变更：
无

效果图：
![image](https://user-images.githubusercontent.com/61003590/157000674-70738cec-7079-4b17-90d6-6201c1b6bd3d.png)

